### PR TITLE
fix: remove optional quantifier for capture

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -49,7 +49,7 @@ module.exports = grammar({
       optional($.quantifier),
     ),
 
-    escape_char: _ => token.immediate(/\W/),
+    escape_char: _ => token.immediate(/[^a-zA-Z0-9]/),
     capture_index: _ => token.immediate(/[1-9]/),
     balanced_match: $ => seq(
       token.immediate('b'),
@@ -141,7 +141,6 @@ module.exports = grammar({
         ),
       ),
       token.immediate(')'),
-      optional($.quantifier),
     ),
   },
 });


### PR DESCRIPTION
I'm not too sure how to update the other files, so that will need doing before this can be merged.

There are two changes here (the first one is moderately important, while the second one is fairly inconsequential):
- Remove optional quantifier for captures (quantifiers in lua patterns are only available for character sets and character classes).
- Change escaped_char to also allow `_` (according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Cheatsheet `\W` is equivalent to `[a-zA-Z0-9_]`). This change is because the lua manual says that any non-alphanumeric character can be escaped.